### PR TITLE
Download CLI on Windows

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -140,7 +140,7 @@ async function downloadCli(cxVersion, skipIfFail) {
                     if (utils.is8Version(cxVersion)) {
                         if (fs.existsSync(zipFileName)) {
                             if(isWin) {
-                                await exec.exec("powershell.exe Expand-Archive -LiteralPath " + zipFileName)
+                                await exec.exec("powershell.exe Expand-Archive -LiteralPath " + zipFileName + " -DestinationPath .")
                             } else {
                                 await exec.exec("unzip -q " + zipFileName)
                             }

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -132,22 +132,38 @@ async function downloadCli(cxVersion, skipIfFail) {
                 const cliExists = fs.existsSync(CLI_FOLDER_NAME)
                 if (!cliExists) {
                     core.info("Checkmarx CLI does not exist in the path. Trying to download...\n")
-                    await exec.exec("curl -s " + cliDownloadUrl + FILE_EXTENSION + " -L -o " + zipFileName)
+                    if(isWin) {
+                        await exec.exec("powershell.exe Invoke-WebRequest -Uri " + cliDownloadUrl + FILE_EXTENSION + " -OutFile " + zipFileName)
+                    } else {
+                        await exec.exec("curl -s " + cliDownloadUrl + FILE_EXTENSION + " -L -o " + zipFileName)
+                    }
                     if (utils.is8Version(cxVersion)) {
                         if (fs.existsSync(zipFileName)) {
-                            await exec.exec("unzip -q " + zipFileName)
+                            if(isWin) {
+                                await exec.exec("powershell.exe Expand-Archive -LiteralPath " + zipFileName)
+                            } else {
+                                await exec.exec("unzip -q " + zipFileName)
+                            }
                         } else {
                             core.info("Checkmarx CLI Zip File " + zipFileName + " does not exists")
                         }
                     } else {
                         if (fs.existsSync(zipFileName)) {
-                            await exec.exec("unzip -q " + zipFileName + " -d " + CLI_FOLDER_NAME)
+                            if(isWin) {
+                                await exec.exec("powershell.exe Expand-Archive -LiteralPath " + zipFileName + " -DestinationPath " + CLI_FOLDER_NAME)
+                            } else {
+                                await exec.exec("unzip -q " + zipFileName + " -d " + CLI_FOLDER_NAME)
+                            }
                         } else {
                             core.info("Checkmarx CLI Zip File " + zipFileName + " does not exists")
                         }
                     }
                     if (fs.existsSync(zipFileName)) {
-                        await exec.exec("rm -rf " + zipFileName)
+                        if(isWin) {
+                            await exec.exec("def -f " + zipFileName)
+                        } else {
+                            await exec.exec("rm -rf " + zipFileName)
+                        }
                     } else {
                         core.info("Checkmarx CLI Zip File " + zipFileName + " does not exists")
                     }
@@ -164,7 +180,11 @@ async function downloadCli(cxVersion, skipIfFail) {
                         }
                         const examplesFolder = "./" + CLI_FOLDER_NAME + "/Examples"
                         if (fs.existsSync(examplesFolder)) {
-                            await exec.exec("rm -rf " + examplesFolder)
+                            if(isWin) {
+                                await exec.exec("del -f " + examplesFolder)
+                            } else {
+                                await exec.exec("rm -rf " + examplesFolder)
+                            }
                         } else {
                             core.info("Checkmarx CLI Examples Folder " + examplesFolder + " does not exists")
                         }
@@ -182,7 +202,11 @@ async function downloadCli(cxVersion, skipIfFail) {
                     }
                 }
 
-                await exec.exec("ls -la")
+                if(isWin) {
+                    await exec.exec("dir")
+                } else {
+                    await exec.exec("ls -la")
+                }
 
                 core.info("[END] Download Checkmarx CLI...\n")
                 return true

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -160,7 +160,7 @@ async function downloadCli(cxVersion, skipIfFail) {
                     }
                     if (fs.existsSync(zipFileName)) {
                         if(isWin) {
-                            await exec.exec("def -f " + zipFileName)
+                            await exec.exec("del -f " + zipFileName)
                         } else {
                             await exec.exec("rm -rf " + zipFileName)
                         }

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -194,12 +194,7 @@ async function downloadCli(cxVersion, skipIfFail) {
                         }
                     }
                 }
-                if (isWin) {
-                    const runWindows = "." + path.sep + CLI_FOLDER_NAME + path.sep + "runCxConsole.cmd"
-                    if (fs.existsSync(runWindows)) {
-                        await exec.exec("chmod +x " + runWindows)
-                    }
-                } else {
+                if (!isWin) {
                     const runLinux = "." + path.sep + CLI_FOLDER_NAME + path.sep + "runCxConsole.sh"
                     if (fs.existsSync(runLinux)) {
                         await exec.exec("chmod +x " + runLinux)

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -160,7 +160,7 @@ async function downloadCli(cxVersion, skipIfFail) {
                     }
                     if (fs.existsSync(zipFileName)) {
                         if(isWin) {
-                            await exec.exec("del -f " + zipFileName)
+                            await exec.exec("powershell.exe Remove-Item " + zipFileName + " -Force")
                         } else {
                             await exec.exec("rm -rf " + zipFileName)
                         }
@@ -181,7 +181,7 @@ async function downloadCli(cxVersion, skipIfFail) {
                         const examplesFolder = "./" + CLI_FOLDER_NAME + "/Examples"
                         if (fs.existsSync(examplesFolder)) {
                             if(isWin) {
-                                await exec.exec("del -f " + examplesFolder)
+                                await exec.exec("powershell.exe Remove-Item " + examplesFolder + " -Recurse -Force")
                             } else {
                                 await exec.exec("rm -rf " + examplesFolder)
                             }
@@ -203,7 +203,7 @@ async function downloadCli(cxVersion, skipIfFail) {
                 }
 
                 if(isWin) {
-                    await exec.exec("dir")
+                    await exec.exec("powershell.exe Get-ChildItem")
                 } else {
                     await exec.exec("ls -la")
                 }

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -174,7 +174,11 @@ async function downloadCli(cxVersion, skipIfFail) {
                 if (!cliExists) {
                     if (utils.is8Version(cxVersion)) {
                         if (fs.existsSync(versionFileName)) {
-                            await exec.exec("mv " + versionFileName + " " + CLI_FOLDER_NAME)
+                            if(isWin) {
+                                await exec.exec("powershell.exe Move-Item -Path " + versionFileName + " -Destination " + CLI_FOLDER_NAME)
+                            } else {
+                                await exec.exec("mv " + versionFileName + " " + CLI_FOLDER_NAME)
+                            }
                         } else {
                             core.info("Checkmarx CLI Version Folder " + versionFileName + " does not exists")
                         }


### PR DESCRIPTION
Fixes #212 

If you run the `checkmarx-github-action` on a `self-hosted` windows box, it fails to download the `.zip`.  This is probably due to the fact that a lot of windows boxes don't have `curl` (as it doesn't come by default).  There is already an `isWin` check in the `cli.js` file, so using that I was able to replace the `linux` specific commands with `powershell`.  This should increase compatibility without the need to change much on your runner.

### Changes
`curl` -> `Invoke-WebRequest`
`unzip` -> `Expand-Archive`
`rm` -> `Remove-Item`
`mv` -> `Move-Item`
`ls` -> `Get-ChildItem`

With my testing, the runner that had the issue was able to run scans after these changes without making any changes to the box.