### PR TITLE
security: pin docker images to sha256 digests

### DIFF
--- a/Dockerfile-linux
+++ b/Dockerfile-linux
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:latest@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1
 
 RUN node --version && \
     npm --version

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore:ltsc2019@sha256:59d374d44d844cef8de438d60fac13c22e1841f06e28c665d734822b878f5d55
 
 RUN powershell Set-ExecutionPolicy Bypass -Scope Process -Force
 RUN powershell [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072


### PR DESCRIPTION
Replaces 2 image references across 2 files with @sha256:<digest>
pinned forms. Defends against tag mutation / supply-chain attacks.

Pinned images:
  - mcr.microsoft.com/windows/servercore:ltsc2019 -> mcr.microsoft.com/windows/servercore:ltsc2019@sha256:59d374d44d844cef8de438d60fac13c22e1841f06e28c665d734822b878f5d55
  - node:latest -> node:latest@sha256:f9a1756160a9e1c3dca456bc0b185bf8f2f112a6771c694df87288046f4306f1

Generated by docker-image-pinner from plan-dev-4.csv.